### PR TITLE
GH-58: Point build to new DockerHub account

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: freenodecsharp/spike_core
+        repository: liberacsharp/spike_core
         tags: latest
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
* Update GH Actions configuration to point to `liberacsharp/spikecore`
  instead of `freenodecsharp/spikecore`
  
  close #58 