### PR TITLE
GH-61: Publish ARM64 Docker image

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -30,11 +30,22 @@ jobs:
       run: dotnet publish --configuration Release
       working-directory: src/SpikeCore
 
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: liberacsharp/spike_core
-        tags: latest
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push:  ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        tags: liberacsharp/spike_core:latest

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v2


### PR DESCRIPTION
* Should now publish both a `linux/amd64` and a `linux/arm64` flavored Docker image
* Move from `docker/build-push-action@v1`  to `docker/build-push-action@v2`
    * Uses the `docker/setup-qemu-action@v1` step to build ARM64 images
    * Also uses the new `docker/login-action@v1` to obtain credentials
    * Will still use the same push logic (GitHub event is `push`, and the ref is `refs/heads/master`)
    * Will still push the same tag (`liberacsharp/spike_core:latest`)

Closes #61